### PR TITLE
Add async/await shim

### DIFF
--- a/Sources/StructuredAPIClient/NetworkClient+AsyncAwait.swift
+++ b/Sources/StructuredAPIClient/NetworkClient+AsyncAwait.swift
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the StructuredAPIClient open source project
+//
+// Copyright (c) Stairtree GmbH
+// Licensed under the MIT license
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+extension NetworkClient {
+   public func load<Request: NetworkRequest>(_ req: Request) async throws -> Request.ResponseDataType {
+        try await withCheckedThrowingContinuation { continuation in
+            self.load(req) { switch $0 {
+                case .success(let value): continuation.resume(returning: value)
+                case .failure(let error): continuation.resume(throwing: error)
+            } }
+        }
+    }
+}

--- a/Sources/StructuredAPIClient/NetworkClient+AsyncAwait.swift
+++ b/Sources/StructuredAPIClient/NetworkClient+AsyncAwait.swift
@@ -16,6 +16,8 @@ import Foundation
 import FoundationNetworking
 #endif
 
+#if compiler(>=5.5) && canImport(_Concurrency)
+
 @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
 extension NetworkClient {
    public func load<Request: NetworkRequest>(_ req: Request) async throws -> Request.ResponseDataType {
@@ -27,3 +29,5 @@ extension NetworkClient {
         }
     }
 }
+
+#endif

--- a/Sources/StructuredAPIClient/NetworkClient+AsyncAwait.swift
+++ b/Sources/StructuredAPIClient/NetworkClient+AsyncAwait.swift
@@ -16,7 +16,7 @@ import Foundation
 import FoundationNetworking
 #endif
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5) && canImport(_Concurrency) && canImport(Darwin)
 
 @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
 extension NetworkClient {

--- a/Sources/StructuredAPIClient/Transport/URLSessionTransport+AsyncAwait.swift
+++ b/Sources/StructuredAPIClient/Transport/URLSessionTransport+AsyncAwait.swift
@@ -16,7 +16,7 @@ import Foundation
 import FoundationNetworking
 #endif
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5) && canImport(_Concurrency) && canImport(Darwin)
 
 @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
 extension URLSessionTransport {

--- a/Sources/StructuredAPIClient/Transport/URLSessionTransport+AsyncAwait.swift
+++ b/Sources/StructuredAPIClient/Transport/URLSessionTransport+AsyncAwait.swift
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the StructuredAPIClient open source project
+//
+// Copyright (c) Stairtree GmbH
+// Licensed under the MIT license
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+#if compiler(>=5.5) && canImport(_Concurrency)
+
+@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+extension URLSessionTransport {
+    
+    /// Sends the request using a `URLSessionDataTask`
+    /// - Parameter request: The configured request to send.
+    /// - Returns: The received response from the server.
+    public func send(request: URLRequest) async throws -> TransportResponse {
+        do {
+            let (data, response) = try await session.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw TransportFailure.network(URLError(.unsupportedURL))
+            }
+            return httpResponse.asTransportResponse(withData: data)
+            
+        } catch let netError as URLError {
+            if netError.code == .cancelled { throw TransportFailure.cancelled }
+            throw TransportFailure.network(netError)
+            
+        } catch let error as TransportFailure {
+            throw error
+            
+        } catch {
+            throw TransportFailure.unknown(error)
+        }
+    }
+}
+
+#endif

--- a/Sources/StructuredAPIClient/Transport/URLSessionTransport+Combine.swift
+++ b/Sources/StructuredAPIClient/Transport/URLSessionTransport+Combine.swift
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the StructuredAPIClient open source project
+//
+// Copyright (c) Stairtree GmbH
+// Licensed under the MIT license
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+#if canImport(Combine)
+import Combine
+
+@available(iOS 13.0, macOS 10.15, watchOS 6.0, tvOS 13.0, *)
+extension URLSessionTransport {
+    public func publisher(forRequest request: URLRequest) -> AnyPublisher<TransportResponse, Error> {
+        return self.session.dataTaskPublisher(for: request)
+            .mapError { netError -> Error in
+                if netError.code == .cancelled { return TransportFailure.cancelled }
+                else { return TransportFailure.network(netError) }
+            }
+            .tryMap { output in
+                guard let response = output.response as? HTTPURLResponse else {
+                    throw TransportFailure.network(URLError(.unsupportedURL))
+                }
+                return response.asTransportResponse(withData: output.data)
+            }
+            .eraseToAnyPublisher()
+    }
+}
+#endif
+

--- a/Sources/StructuredAPIClient/Transport/URLSessionTransport.swift
+++ b/Sources/StructuredAPIClient/Transport/URLSessionTransport.swift
@@ -61,6 +61,33 @@ public final class URLSessionTransport: Transport {
     }
 }
 
+@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+extension URLSessionTransport {
+    
+    /// Sends the request using a `URLSessionDataTask`
+    /// - Parameter request: The configured request to send.
+    /// - Returns: The received response from the server.
+    public func send(request: URLRequest) async throws -> TransportResponse {
+        do {
+            let (data, response) = try await session.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw TransportFailure.network(URLError(.unsupportedURL))
+            }
+            return httpResponse.asTransportResponse(withData: data)
+            
+        } catch let netError as URLError {
+            if netError.code == .cancelled { throw TransportFailure.cancelled }
+            throw TransportFailure.network(netError)
+            
+        } catch let error as TransportFailure {
+            throw error
+            
+        } catch {
+            throw TransportFailure.unknown(error)
+        }
+    }
+}
+
 #if canImport(Combine)
 import Combine
 

--- a/Tests/StructuredAPIClientTests/NetworkClientWithAsyncAwaitTests.swift
+++ b/Tests/StructuredAPIClientTests/NetworkClientWithAsyncAwaitTests.swift
@@ -18,6 +18,8 @@ import FoundationNetworking
 @testable import StructuredAPIClient
 import StructuredAPIClientTestSupport
 
+#if compiler(>=5.5) && canImport(_Concurrency)
+
 @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
 final class NetworkClientWithAsyncAwaitTests: XCTestCase {
     
@@ -73,3 +75,5 @@ final class NetworkClientWithAsyncAwaitTests: XCTestCase {
         XCTAssertEqual(client.baseURL.absoluteString, "https://test.somewhere.com")
     }
 }
+
+#endif

--- a/Tests/StructuredAPIClientTests/NetworkClientWithAsyncAwaitTests.swift
+++ b/Tests/StructuredAPIClientTests/NetworkClientWithAsyncAwaitTests.swift
@@ -1,0 +1,75 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the StructuredAPIClient open source project
+//
+// Copyright (c) Stairtree GmbH
+// Licensed under the MIT license
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+@testable import StructuredAPIClient
+import StructuredAPIClientTestSupport
+
+@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+final class NetworkClientWithAsyncAwaitTests: XCTestCase {
+    
+    func testNetworkClientWithAsyncAwait() async throws {
+        struct TestRequest: NetworkRequest {
+            func makeRequest(baseURL: URL) throws -> URLRequest { URLRequest(url: baseURL) }
+            func parseResponse(_ response: TransportResponse) throws -> String { .init(decoding: response.body, as: UTF8.self) }
+        }
+        
+        let response: Result<TransportResponse, Error> = .success(.init(status: .ok, headers: [:], body: Data("Test".utf8)))
+        
+        let requestAssertions: (URLRequest) -> Void = {
+            XCTAssertEqual($0.url, URL(string: "https://test.somewhere.com")!)
+        }
+        
+        let client = NetworkClient(baseURL: URL(string: "https://test.somewhere.com")!, transport: TestTransport(responses: [response], assertRequest: requestAssertions))
+        
+        let value = try await client.load(TestRequest())
+        
+        XCTAssertEqual(value, "Test")
+        XCTAssertEqual(client.baseURL.absoluteString, "https://test.somewhere.com")
+    }
+    
+    func testTokenAuthWithAsyncAwait() async throws {
+        struct TestRequest: NetworkRequest {
+            func makeRequest(baseURL: URL) throws -> URLRequest { URLRequest(url: baseURL) }
+            func parseResponse(_ response: TransportResponse) throws -> String { .init(decoding: response.body, as: UTF8.self) }
+        }
+
+        let accessToken = TestToken(raw: "abc", expiresAt: Date())
+        let refreshToken = TestToken(raw: "def", expiresAt: Date())
+
+        let tokenProvider = TestTokenProvider(accessToken: accessToken, refreshToken: refreshToken)
+
+        let response: Result<TransportResponse, Error> = .success(.init(status: .ok, headers: [:], body: Data("Test".utf8)))
+
+        let requestAssertions: (URLRequest) -> Void = {
+            XCTAssertEqual($0.url, URL(string: "https://test.somewhere.com")!)
+            XCTAssertEqual($0.allHTTPHeaderFields?["Authorization"], "Bearer abc")
+        }
+
+        let client = NetworkClient(
+            baseURL: URL(string: "https://test.somewhere.com")!,
+            transport: TokenAuthenticationHandler(
+                base: TestTransport(responses: [response], assertRequest: requestAssertions),
+                tokenProvider: tokenProvider
+            )
+        )
+        
+        let value = try await client.load(TestRequest())
+        
+        XCTAssertEqual(value, "Test")
+        XCTAssertEqual(client.baseURL.absoluteString, "https://test.somewhere.com")
+    }
+}

--- a/Tests/StructuredAPIClientTests/NetworkClientWithAsyncAwaitTests.swift
+++ b/Tests/StructuredAPIClientTests/NetworkClientWithAsyncAwaitTests.swift
@@ -18,7 +18,7 @@ import FoundationNetworking
 @testable import StructuredAPIClient
 import StructuredAPIClientTestSupport
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5) && canImport(_Concurrency) && canImport(Darwin)
 
 @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
 final class NetworkClientWithAsyncAwaitTests: XCTestCase {


### PR DESCRIPTION
This PR adds an async `NetworkClient.load(_:)` method that uses a `withCheckedThrowingContinuation` to shim the completion handler into an async call.

This is not ideal in the sense that the `Transport` protocol should also make an async variant available, but this can be left for a future PR, as it is tricky concerning backward compatibility.